### PR TITLE
Link ishoudinireadyyet image into website

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The first question that we do when we view a new technology, thanks to [Surma](https://github.com/surma) we have a great table to see the status of APIs and the browsers support.
 
-![Is Houdini ready yet‽](https://user-images.githubusercontent.com/1307927/47389393-ec628f00-d714-11e8-829e-4479eac7a340.jpg)
+[![Is Houdini ready yet‽](https://user-images.githubusercontent.com/1307927/47389393-ec628f00-d714-11e8-829e-4479eac7a340.jpg)](https://ishoudinireadyyet.com/)
 [Is Houdini ready yet‽](https://ishoudinireadyyet.com/)
 
 ### 📚 Documentation


### PR DESCRIPTION
instead of open source image, when _clicking_ the image go to the updated [website](https://ishoudinireadyyet.com/)

I leave the link below as an extra chance.

Great list of **awesome** resources @nucliweb!