### PR TITLE
Switch to https for slides.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The first question that we do when we view a new technology, thanks to [Surma](h
 - [Make the Web Brighter with the CSS Paint API](https://speakerdeck.com/bobrov1989/make-the-web-brighter-with-the-css-paint-api-1c99ed50-7d7d-43b4-bc1e-7f41684274ed)
 - [WebAssembly in Houdini CSS, is it possible?](https://www.slideshare.net/gskachkov/webassembly-in-houdini-css-is-it-possible)
 - [Design System Magic with Houdini](https://css-houdini.web.app/talks/design-systems/)
-- [When Houdini met Goldblum](http://slides.com/oliverturner/when-houdini-met-goldblum)
+- [When Houdini met Goldblum](https://slides.com/oliverturner/when-houdini-met-goldblum)
 
 ---
 


### PR DESCRIPTION
Houdini is required per spec to run over a secure connection: this
change lets visitors see jeffsum.oliverturner.com in all its glory ♥️